### PR TITLE
Add model download progress and show active model

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Foreground service (dataSync) on targetSdk 34 -->
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <!-- Removed: android.permission.FOREGROUND_SERVICE_MEDIA_PROCESSING -->

--- a/app/src/main/java/com/share2text/share/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/share2text/share/ui/screens/HomeScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import kotlinx.coroutines.launch
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.share2text.share.viewmodel.ModelViewModel
 
 @Composable
-fun HomeScreen(nav: NavHostController) {
+fun HomeScreen(nav: NavHostController, vm: ModelViewModel = hiltViewModel()) {
+    val state by vm.state.collectAsState()
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -19,7 +22,9 @@ fun HomeScreen(nav: NavHostController) {
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text("Share2Text", style = MaterialTheme.typography.headlineMedium)
+        val activeName = state.presets.find { it.id == state.activeId }?.displayName
         Text("Local Whisper transcription")
+        Text("Active model: ${activeName ?: "None"}")
 
         Button(onClick = { nav.navigate("models") }, modifier = Modifier.fillMaxWidth()) {
             Text("Choose / Download Model")

--- a/app/src/main/java/com/share2text/share/ui/screens/ModelPickerScreen.kt
+++ b/app/src/main/java/com/share2text/share/ui/screens/ModelPickerScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
-import com.share2text.share.download.ModelRepository
 import com.share2text.share.viewmodel.ModelViewModel
 
 @Composable
@@ -20,12 +19,28 @@ fun ModelPickerScreen(nav: NavHostController, vm: ModelViewModel = hiltViewModel
         Spacer(Modifier.height(8.dp))
         LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             items(state.presets) { p ->
+                val progress = state.progress[p.id]
+                val downloaded = state.downloaded.contains(p.id)
                 ElevatedCard(onClick = {}, modifier = Modifier.fillMaxWidth()) {
                     Column(Modifier.padding(12.dp)) {
                         Text(p.displayName)
                         Text(p.url, style = MaterialTheme.typography.bodySmall)
+                        if (progress != null) {
+                            LinearProgressIndicator(progress = if (progress >= 0) progress / 100f else 0f, modifier = Modifier.fillMaxWidth())
+                            Text("$progress%", style = MaterialTheme.typography.bodySmall)
+                        }
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Button(onClick = { vm.download(p) }) { Text("Download") }
+                            when {
+                                progress != null -> {
+                                    Text("Downloading...", style = MaterialTheme.typography.bodySmall)
+                                }
+                                !downloaded -> {
+                                    Button(onClick = { vm.download(p) }) { Text("Download") }
+                                }
+                                else -> {
+                                    Text("Downloaded", style = MaterialTheme.typography.bodySmall)
+                                }
+                            }
                             if (state.activeId == p.id) {
                                 AssistChip(onClick = {}, label = { Text("Active") })
                             } else {

--- a/app/src/main/java/com/share2text/share/viewmodel/ModelViewModel.kt
+++ b/app/src/main/java/com/share2text/share/viewmodel/ModelViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import androidx.work.WorkInfo
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,16 +20,45 @@ class ModelViewModel @Inject constructor(
 
     data class State(
         val presets: List<ModelRepository.ModelPreset> = emptyList(),
-        val activeId: String? = null
+        val activeId: String? = null,
+        val downloaded: Set<String> = emptySet(),
+        val progress: Map<String, Int> = emptyMap()
     )
 
-    private val _state = MutableStateFlow(State(presets = repo.presets))
+    private val _state = MutableStateFlow(
+        State(
+            presets = repo.presets,
+            downloaded = repo.presets.filter { repo.isDownloaded(it) }.map { it.id }.toSet()
+        )
+    )
     val state: StateFlow<State> = _state
 
     init {
         viewModelScope.launch {
             repo.activeModelFlow(dataStore).collect { id ->
                 _state.value = _state.value.copy(activeId = id)
+            }
+        }
+
+        repo.presets.forEach { p ->
+            viewModelScope.launch {
+                repo.downloadStatus(p).collect { status ->
+                    val prog = _state.value.progress.toMutableMap()
+                    val down = _state.value.downloaded.toMutableSet()
+                    when (status.state) {
+                        WorkInfo.State.SUCCEEDED -> {
+                            prog.remove(p.id)
+                            down.add(p.id)
+                        }
+                        WorkInfo.State.RUNNING, WorkInfo.State.ENQUEUED -> {
+                            prog[p.id] = status.progress
+                        }
+                        else -> {
+                            prog.remove(p.id)
+                        }
+                    }
+                    _state.value = _state.value.copy(progress = prog, downloaded = down)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add network permission and repository helpers for model download status
- track download progress and downloaded models via `ModelViewModel`
- show progress/UI state in model picker and active model on home screen

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6be71afb48320aa27cda7cfa8c2e7