### PR TITLE
feat: show model download progress and active model

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.9.2")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.4")
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
     // Hilt (use KSP instead of KAPT)

--- a/app/src/main/java/com/share2text/share/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/share2text/share/ui/screens/HomeScreen.kt
@@ -7,10 +7,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import kotlinx.coroutines.launch
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.share2text.share.viewmodel.ModelViewModel
 
 @Composable
-fun HomeScreen(nav: NavHostController) {
+fun HomeScreen(nav: NavHostController, vm: ModelViewModel = hiltViewModel()) {
+    val state by vm.state.collectAsState()
+    val activeName = state.presets.find { it.id == state.activeId }?.displayName ?: "None"
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -20,6 +23,7 @@ fun HomeScreen(nav: NavHostController) {
     ) {
         Text("Share2Text", style = MaterialTheme.typography.headlineMedium)
         Text("Local Whisper transcription")
+        Text("Active model: $activeName")
 
         Button(onClick = { nav.navigate("models") }, modifier = Modifier.fillMaxWidth()) {
             Text("Choose / Download Model")

--- a/app/src/main/java/com/share2text/share/ui/screens/ModelPickerScreen.kt
+++ b/app/src/main/java/com/share2text/share/ui/screens/ModelPickerScreen.kt
@@ -24,8 +24,22 @@ fun ModelPickerScreen(nav: NavHostController, vm: ModelViewModel = hiltViewModel
                     Column(Modifier.padding(12.dp)) {
                         Text(p.displayName)
                         Text(p.url, style = MaterialTheme.typography.bodySmall)
+                        val progress = state.progress[p.id]
+                        if (progress != null && progress < 100) {
+                            LinearProgressIndicator(
+                                progress = progress / 100f,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp)
+                            )
+                            Text("$progress%", style = MaterialTheme.typography.bodySmall)
+                        }
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Button(onClick = { vm.download(p) }) { Text("Download") }
+                            if (progress == null || progress >= 100) {
+                                Button(onClick = { vm.download(p) }) { Text("Download") }
+                            } else {
+                                OutlinedButton(onClick = {}, enabled = false) { Text("Downloading") }
+                            }
                             if (state.activeId == p.id) {
                                 AssistChip(onClick = {}, label = { Text("Active") })
                             } else {


### PR DESCRIPTION
## Summary
- track and expose model download progress
- display progress in model picker and show currently active model on home
- add LiveData dependency and suppress notification permission lint

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a74737bd2c832084c1fd9a49bf9ee8